### PR TITLE
home-manager: fix systemd target on wayland

### DIFF
--- a/nix/hm.nix
+++ b/nix/hm.nix
@@ -22,6 +22,8 @@ in {
       Unit = {
         After = [cfg.systemdTarget];
         PartOf = [cfg.systemdTarget];
+      } // lib.optionalAttrs (!config.xsession.enable) {
+        ConditionEnvironment = "WAYLAND_DISPLAY";
       };
 
       Service = {

--- a/nix/hm.nix
+++ b/nix/hm.nix
@@ -20,7 +20,8 @@ in {
       configFile = (pkgs.formats.toml {}).generate "config.toml" cfg.config;
     in {
       Unit = {
-        After = ["graphical-session.target"];
+        After = [cfg.systemdTarget];
+        PartOf = [cfg.systemdTarget];
       };
 
       Service = {
@@ -29,7 +30,7 @@ in {
       };
 
       Install = {
-        WantedBy = ["graphical-session.target"];
+        WantedBy = [cfg.systemdTarget];
       };
     };
 

--- a/nix/options.nix
+++ b/nix/options.nix
@@ -15,6 +15,12 @@ in {
       description = "The xdg-desktop-portal-termfilepickers package";
     };
 
+    systemdTarget = mkOption {
+      type = types.str;
+      description = "The target that should want the service";
+      default = config.wayland.systemd.target;
+    };
+
     desktopEnvironments = mkOption {
       type = types.listOf types.str;
       default = ["common"];


### PR DESCRIPTION
Since https://github.com/nix-community/home-manager/pull/6253, there is an option `wayland.systemd.target` that all user services should be `WantedBy=`, `PartOf=`, and `After=` to ensure they properly start and stop with the wayland session.

Also require `WAYLAND_DISPLAY` for good measure as wayland-native terminal emulators (e.g. foot) need this to start.